### PR TITLE
Fix install on CentOS 7

### DIFF
--- a/.kitchen.ci.yml
+++ b/.kitchen.ci.yml
@@ -10,9 +10,13 @@ provisioner:
 
 platforms:
   - name: centos-6.6
+  - name: centos-7.1
 
 suites:
   - name: default
     run_list:
       - recipe[ratpoison::default]
     attributes:
+      ratpoison:
+        rpm:
+          url: https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,9 +7,13 @@ provisioner:
 
 platforms:
   - name: centos-6.6
+  - name: centos-7.1
 
 suites:
   - name: default
     run_list:
       - recipe[ratpoison::default]
     attributes:
+      ratpoison:
+          rpm:
+            url: https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,7 @@ AllCops:
 Style/SingleSpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'
+
+Metrics/LineLength:
+  Max: 120
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Requirements
 Attributes
 ----------
 
+The ratpoison pacckage is not available in Epel repository for CentOS 7.
+The cookbook provides the attribute `default['ratpoison']['rpm']['url']` and to specify the location where to download the ratpoison rpm from.
+This attribute is needed for CentOS verions above 6.
+
 Usage
 -----
 #### ratpoison::default

--- a/attributes/windowmanager.rb
+++ b/attributes/windowmanager.rb
@@ -17,5 +17,8 @@
 # limitations under the License.
 #
 
+default['ratpoison']['rpm']['url']  = nil
+default['ratpoison']['rpm']['file'] = "#{Chef::Config[:file_cache_path]}/ratpoison.rpm"
+
 default['ratpoison']['display'] = ':0'
 default['ratpoison']['screen']  = '0'

--- a/recipes/windowmanager.rb
+++ b/recipes/windowmanager.rb
@@ -19,7 +19,13 @@
 
 include_recipe 'yum-epel'
 
-package 'ratpoison'
+remote_file node['ratpoison']['rpm']['file'] do
+  source node['ratpoison']['rpm']['url']
+end if node['platform_version'].to_i > 6
+
+package 'ratpoison' do
+  source node['ratpoison']['rpm']['file'] if node['platform_version'].to_i > 6
+end
 
 template '/etc/init.d/ratpoison' do
   source 'ratpoison.init.d.erb'

--- a/recipes/windowmanager.rb
+++ b/recipes/windowmanager.rb
@@ -21,10 +21,10 @@ include_recipe 'yum-epel'
 
 remote_file node['ratpoison']['rpm']['file'] do
   source node['ratpoison']['rpm']['url']
-end if node['platform_version'].to_i > 6
+end if node['platform_version'].to_f >= 7.0
 
 package 'ratpoison' do
-  source node['ratpoison']['rpm']['file'] if node['platform_version'].to_i > 6
+  source node['ratpoison']['rpm']['file'] if node['platform_version'].to_f >= 7.0
 end
 
 template '/etc/init.d/ratpoison' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -15,18 +15,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-require 'chefspec'
 require_relative 'spec_helper'
 
 describe 'ratpoison::default' do
-  let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
+  context 'when installing on CentOS 6.6' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6').converge(described_recipe) }
 
-  it 'includes the xvfb cookbook' do
-    expect(chef_run).to include_recipe('xvfb')
+    it 'includes the xvfb cookbook' do
+      expect(chef_run).to include_recipe('xvfb')
+    end
+
+    it 'includes the ratpoison::windowmanager recipe' do
+      expect(chef_run).to include_recipe('ratpoison::windowmanager')
+    end
   end
 
-  it 'includes the ratpoison::windowmanager recipe' do
-    expect(chef_run).to include_recipe('ratpoison::windowmanager')
+  context 'when installing on CentoOS 7.1' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503') do |node|
+        node.set['ratpoison']['rpm']['url'] = 'https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the xvfb cookbook' do
+      expect(chef_run).to include_recipe('xvfb')
+    end
+
+    it 'includes the ratpoison::windowmanager recipe' do
+      expect(chef_run).to include_recipe('ratpoison::windowmanager')
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'simplecov'
 
-SimpleCov.start do
-  add_filter '/test/'
-end
-
-RSpec.configure do |config|
-  config.platform = 'centos'
-  config.version  = '6.6'
+ChefSpec::Coverage.start! do
+  add_filter 'vendor/'
+  add_filter 'test/'
 end

--- a/spec/windowmanager_spec.rb
+++ b/spec/windowmanager_spec.rb
@@ -19,10 +19,19 @@ require_relative 'spec_helper'
 
 describe 'ratpoison::windowmanager' do
   context 'when installing on CentOS 6.6' do
-    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6').converge(described_recipe) }
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6') do |node|
+        node.set['ratpoison']['rpm']['file'] = 'some_dir/ratpoison.rpm'
+        node.set['ratpoison']['rpm']['url']  = 'https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm'
+      end.converge(described_recipe)
+    end
 
     it 'includes the yum-epel cookbook' do
       expect(chef_run).to include_recipe('yum-epel')
+    end
+
+    it 'does not download ratpoison rpm' do
+      expect(chef_run).not_to create_remote_file(chef_run.node['ratpoison']['rpm']['file'])
     end
 
     it 'installs package retpoison' do

--- a/spec/windowmanager_spec.rb
+++ b/spec/windowmanager_spec.rb
@@ -45,6 +45,11 @@ describe 'ratpoison::windowmanager' do
       expect(chef_run.template(init_script_file)).to notify('service[ratpoison]')
         .to(:restart)
     end
+
+    it 'starts the ratpoison service' do
+      expect(chef_run).to start_service('ratpoison')
+      expect(chef_run).to enable_service('ratpoison')
+    end
   end
 
   context 'when installing on CentoOS 7.1' do
@@ -82,6 +87,11 @@ describe 'ratpoison::windowmanager' do
     it 'notifies ratpoison service to restart' do
       expect(chef_run.template(init_script_file)).to notify('service[ratpoison]')
         .to(:restart)
+    end
+
+    it 'starts the ratpoison service' do
+      expect(chef_run).to start_service('ratpoison')
+      expect(chef_run).to enable_service('ratpoison')
     end
   end
 end

--- a/spec/windowmanager_spec.rb
+++ b/spec/windowmanager_spec.rb
@@ -15,31 +15,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-require 'chefspec'
 require_relative 'spec_helper'
 
 describe 'ratpoison::windowmanager' do
-  let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
 
-  it 'includes the yum-epel cookbook' do
-    expect(chef_run).to include_recipe('yum-epel')
+  context 'when installing on CentOS 6.6' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6').converge(described_recipe) }
+
+    it 'includes the yum-epel cookbook' do
+      expect(chef_run).to include_recipe('yum-epel')
+    end
+
+    it 'installs package retpoison' do
+      expect(chef_run).to install_package('ratpoison')
+    end
+
+    init_script_file = '/etc/init.d/ratpoison'
+
+    it "creates #{init_script_file} template" do
+      expect(chef_run).to create_template(init_script_file)
+        .with_mode(00755)
+    end
+
+    it "creates #{init_script_file} init script" do
+      expect(chef_run).to render_file(init_script_file)
+        .with_content("args=\"-d :0 -s 0\"")
+    end
+
+    it 'notifies ratpoison service to restart' do
+      expect(chef_run.template(init_script_file)).to notify('service[ratpoison]')
+        .to(:restart)
+    end
   end
 
-  init_script_file = '/etc/init.d/ratpoison'
+  context 'when installing on CentoOS 7.1' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503') do |node|
+        node.set['ratpoison']['rpm']['url'] = 'https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm'
+      end.converge(described_recipe)
+    end
 
-  it "creates #{init_script_file} template" do
-    expect(chef_run).to create_template(init_script_file)
-      .with_mode(00755)
-  end
+    it 'includes the yum-epel cookbook' do
+      expect(chef_run).to include_recipe('yum-epel')
+    end
 
-  it "creates #{init_script_file} init script" do
-    expect(chef_run).to render_file(init_script_file)
-      .with_content("args=\"-d :0 -s 0\"")
-  end
+    it 'downloads ratpoison rpm' do
+      expect(chef_run).to create_remote_file(chef_run.node['ratpoison']['rpm']['file'])
+    end
 
-  it 'notifies ratpoison service to restart' do
-    expect(chef_run.template(init_script_file)).to notify('service[ratpoison]')
-      .to(:restart)
+    it 'installs package retpoison' do
+      expect(chef_run).to install_package('ratpoison')
+        .with_source(chef_run.node['ratpoison']['rpm']['file'])
+    end
+
+    init_script_file = '/etc/init.d/ratpoison'
+
+    it "creates #{init_script_file} template" do
+      expect(chef_run).to create_template(init_script_file)
+        .with_mode(00755)
+    end
+
+    it "creates #{init_script_file} init script" do
+      expect(chef_run).to render_file(init_script_file)
+        .with_content("args=\"-d :0 -s 0\"")
+    end
+
+    it 'notifies ratpoison service to restart' do
+      expect(chef_run.template(init_script_file)).to notify('service[ratpoison]')
+        .to(:restart)
+    end
   end
 end

--- a/spec/windowmanager_spec.rb
+++ b/spec/windowmanager_spec.rb
@@ -18,7 +18,6 @@
 require_relative 'spec_helper'
 
 describe 'ratpoison::windowmanager' do
-
   context 'when installing on CentOS 6.6' do
     let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6').converge(described_recipe) }
 

--- a/spec/windowmanager_spec.rb
+++ b/spec/windowmanager_spec.rb
@@ -55,7 +55,8 @@ describe 'ratpoison::windowmanager' do
   context 'when installing on CentoOS 7.1' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503') do |node|
-        node.set['ratpoison']['rpm']['url'] = 'https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm'
+        node.set['ratpoison']['rpm']['file'] = 'some_dir/ratpoison.rpm'
+        node.set['ratpoison']['rpm']['url']  = 'https://copr-be.cloud.fedoraproject.org/results/shassard/ratpoison/epel-7-x86_64/ratpoison-1.4.8-1.el7.centos/ratpoison-1.4.8-1.el7.centos.x86_64.rpm'
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
Epel repo for CentOS 7 does not contain an rpm for ratpoison.
This PR adds the possibility to specify the URL where the rpm can be downloaded from.

Fixes #3 