### PR TITLE
Delay service restart after converging init script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'berkshelf', github: 'berkshelf/berkshelf'
+  gem 'berkshelf', git: 'https://github.com/berkshelf/berkshelf'
   gem 'foodcritic', '>= 3.0'
   gem 'chefspec',   '>= 3.1'
   gem 'rubocop'
@@ -9,7 +9,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'vagrant', github: 'mitchellh/vagrant'
+  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant'
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
   gem 'kitchen-docker'

--- a/recipes/windowmanager.rb
+++ b/recipes/windowmanager.rb
@@ -36,7 +36,7 @@ template '/etc/init.d/ratpoison' do
     template_file: source.to_s,
     recipe_file:   (__FILE__).to_s.split('cookbooks/').last
   )
-  notifies(:restart, 'service[ratpoison]')
+  notifies :restart, 'service[ratpoison]', :delayed
 end
 
 service 'ratpoison' do

--- a/run-ci-build.sh
+++ b/run-ci-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
-bundle install --path vendor/bundle
+rm -f Berksfile.lock Gemfile.lock
+
+bundle install --path vendor/bundle --binstubs vendor/bin
 
 bundle exec foodcritic .
 


### PR DESCRIPTION
On a first install the service ends up in a "dead but subsys locked" state.
The next convergence should fix it but that means kitchen tests will fail because they only converge once.

This PR attempts to fix that